### PR TITLE
posixio: add extra functions

### DIFF
--- a/etc/selfie_posixio_functions.txt
+++ b/etc/selfie_posixio_functions.txt
@@ -33,3 +33,7 @@ ssize_t readv(int fd, const struct iovec *iov, int iovcnt)
 ssize_t write(int fd, const void *buf, size_t count)
 ssize_t writev(int fd, const struct iovec *iov, int iovcnt)
 void rewind(FILE *stream)
+void* mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset);
+int munmap(void *addr, size_t length);
+int fcntl(int fd, int cmd, long arg);
+int ioctl(int fd, unsigned long request, void *argp);


### PR DESCRIPTION
ioctl is used quite a bit behind the scene with lustre and could be
used by apps (e.g. setstripe etc)
fcntl is also probably used for file locking and similar activities

mmap I'm not sure if we should include as they are also used to get
memory from anonymous mappings, but if it's file backed I guess it
does count as IO... leaving that up to you

(these were laying around on my disk for probably over a year, but might as well post it?)